### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 tasks:
-  - init: mysqladmin -u root password 'gitpod' && composer creat-project
-      phpmyadmin/phpmyadmin && composer creat-project --prefer-dist
+  - init: mysqladmin -u root password 'gitpod' && composer create-project
+      phpmyadmin/phpmyadmin && composer create-project --prefer-dist
       laravel/laravel
 image:
   file: .gitpod.Dockerfile


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.